### PR TITLE
AddConditionalToSurroundingPairs2

### DIFF
--- a/build/monaco/package.json
+++ b/build/monaco/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monaco-editor-core",
   "private": true,
-  "version": "0.31.1-os",
+  "version": "0.31.1-os2-cnh-1",
   "description": "A browser based code editor",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/build/monaco/package.json
+++ b/build/monaco/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monaco-editor-core",
   "private": true,
-  "version": "0.31.1-os2-cnh-2",
+  "version": "0.31.1-os2-cnh-3",
   "description": "A browser based code editor",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/build/monaco/package.json
+++ b/build/monaco/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monaco-editor-core",
   "private": true,
-  "version": "0.31.1-os2-cnh-1",
+  "version": "0.31.1-os2-cnh-2",
   "description": "A browser based code editor",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/src/vs/editor/common/controller/cursorCommon.ts
+++ b/src/vs/editor/common/controller/cursorCommon.ts
@@ -11,7 +11,7 @@ import { ISelection, Selection } from 'vs/editor/common/core/selection';
 import { ICommand, IConfiguration } from 'vs/editor/common/editorCommon';
 import { ITextModel, PositionAffinity, TextModelResolvedOptions } from 'vs/editor/common/model';
 import { TextModel } from 'vs/editor/common/model/textModel';
-import { AutoClosingPairs, IAutoClosingPair } from 'vs/editor/common/modes/languageConfiguration';
+import { AutoClosingPairs, IAutoClosingPairConditional } from 'vs/editor/common/modes/languageConfiguration';
 import { LanguageConfigurationRegistry } from 'vs/editor/common/modes/languageConfigurationRegistry';
 import { ICoordinatesConverter } from 'vs/editor/common/viewModel/viewModel';
 export { CursorColumns } from './cursorColumns';
@@ -198,7 +198,7 @@ export class CursorConfiguration {
 		}
 	}
 
-	private static _getSurroundingPairs(languageId: string): IAutoClosingPair[] | null {
+	private static _getSurroundingPairs(languageId: string): IAutoClosingPairConditional[] | null {
 		try {
 			return LanguageConfigurationRegistry.getSurroundingPairs(languageId);
 		} catch (e) {

--- a/src/vs/editor/common/modes/languageConfiguration.ts
+++ b/src/vs/editor/common/modes/languageConfiguration.ts
@@ -61,7 +61,7 @@ export interface LanguageConfiguration {
 	 * selected string is surrounded by the open and close characters. If not set, the autoclosing pairs
 	 * settings will be used.
 	 */
-	surroundingPairs?: IAutoClosingPair[];
+	surroundingPairs?: IAutoClosingPairConditional[];
 	/**
 	 * Defines a list of bracket pairs that are colorized depending on their nesting level.
 	 * If not set, the configured brackets will be used.

--- a/src/vs/editor/common/modes/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/modes/languageConfigurationRegistry.ts
@@ -10,7 +10,18 @@ import { LineTokens } from 'vs/editor/common/core/lineTokens';
 import { Range } from 'vs/editor/common/core/range';
 import { ITextModel } from 'vs/editor/common/model';
 import { DEFAULT_WORD_REGEXP, ensureValidWordDefinition } from 'vs/editor/common/model/wordHelper';
-import { EnterAction, FoldingRules, IAutoClosingPair, IndentAction, IndentationRule, LanguageConfiguration, CompleteEnterAction, AutoClosingPairs, CharacterPair, ExplicitLanguageConfiguration } from 'vs/editor/common/modes/languageConfiguration';
+import {
+	EnterAction,
+	FoldingRules,
+	IndentAction,
+	IndentationRule,
+	LanguageConfiguration,
+	CompleteEnterAction,
+	AutoClosingPairs,
+	CharacterPair,
+	ExplicitLanguageConfiguration,
+	IAutoClosingPairConditional
+} from 'vs/editor/common/modes/languageConfiguration';
 import { createScopedLineTokens, ScopedLineTokens } from 'vs/editor/common/modes/supports';
 import { CharacterPairSupport } from 'vs/editor/common/modes/supports/characterPair';
 import { BracketElectricCharacterSupport, IElectricAction } from 'vs/editor/common/modes/supports/electricCharacter';
@@ -272,7 +283,7 @@ export class LanguageConfigurationRegistryImpl {
 		return characterPairSupport.getAutoCloseBeforeSet();
 	}
 
-	public getSurroundingPairs(languageId: string): IAutoClosingPair[] {
+	public getSurroundingPairs(languageId: string): IAutoClosingPairConditional[] {
 		let characterPairSupport = this._getCharacterPairSupport(languageId);
 		if (!characterPairSupport) {
 			return [];

--- a/src/vs/editor/common/modes/supports/characterPair.ts
+++ b/src/vs/editor/common/modes/supports/characterPair.ts
@@ -3,7 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAutoClosingPair, StandardAutoClosingPairConditional, LanguageConfiguration, CharacterPair } from 'vs/editor/common/modes/languageConfiguration';
+import {
+	StandardAutoClosingPairConditional,
+	LanguageConfiguration,
+	CharacterPair,
+	IAutoClosingPairConditional
+} from 'vs/editor/common/modes/languageConfiguration';
 
 export class CharacterPairSupport {
 
@@ -11,7 +16,7 @@ export class CharacterPairSupport {
 	static readonly DEFAULT_AUTOCLOSE_BEFORE_WHITESPACE = ' \n\t';
 
 	private readonly _autoClosingPairs: StandardAutoClosingPairConditional[];
-	private readonly _surroundingPairs: IAutoClosingPair[];
+	private readonly _surroundingPairs: IAutoClosingPairConditional[];
 	private readonly _autoCloseBefore: string;
 	private readonly _colorizedBracketPairs: CharacterPair[];
 
@@ -57,7 +62,7 @@ export class CharacterPairSupport {
 		return this._autoCloseBefore;
 	}
 
-	public getSurroundingPairs(): IAutoClosingPair[] {
+	public getSurroundingPairs(): IAutoClosingPairConditional[] {
 		return this._surroundingPairs;
 	}
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5583,7 +5583,7 @@ declare namespace monaco.languages {
 		 * selected string is surrounded by the open and close characters. If not set, the autoclosing pairs
 		 * settings will be used.
 		 */
-		surroundingPairs?: IAutoClosingPair[];
+		surroundingPairs?: IAutoClosingPairConditional[];
 		/**
 		 * Defines a list of bracket pairs that are colorized depending on their nesting level.
 		 * If not set, the configured brackets will be used.


### PR DESCRIPTION
That's is needed so that we are no able to select a part of a string (which is already surrounded by quotes) and surround it by other chars, like sharp for example. We want the selected string to be replaced and not surrounded.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #
