### PR TITLE
Prevent crash when firstChild is not a text node

### DIFF
--- a/build/monaco/package.json
+++ b/build/monaco/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monaco-editor-core",
   "private": true,
-  "version": "0.55.1-os0.1",
+  "version": "0.55.1-os1",
   "description": "A browser based code editor",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/src/vs/editor/browser/controller/mouseTarget.ts
+++ b/src/vs/editor/browser/controller/mouseTarget.ts
@@ -1172,8 +1172,13 @@ function shadowCaretRangeFromPoint(shadowRoot: ShadowRoot, x: number, y: number)
 		}
 
 		// Creates a range with the text node of the element and set the offset found
-		range.setStart(el.firstChild!, offset);
-		range.setEnd(el.firstChild!, offset);
+		if (el.firstChild!.nodeType ===  Node.TEXT_NODE) {
+			range.setStart(el.firstChild!, offset);
+			range.setEnd(el.firstChild!, offset);
+		} else {
+			range.setStart(el!, 0);
+			range.setEnd(el!, 0);
+		}
 	}
 
 	return range;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This attempts to fix a crash when selecting code with the mouse. It seems to be caused by invisible elements that fall into spots where Monaco expects text nodes instead. This only happens when rendered inside the shadow DOM